### PR TITLE
fix: `VariableDeclaration` without `init` should be ignored

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,9 @@ export default async function convert(options: {
     onWithStatement: onStatement,
     onLabeledStatement: onStatement,
     onVariableDeclarator(node) {
-      onStatement(node.init || node);
+      if (node.init) {
+        onStatement(node.init);
+      }
     },
 
     // Branches

--- a/test/fixtures/variable-declaration/execute.ts
+++ b/test/fixtures/variable-declaration/execute.ts
@@ -1,0 +1,5 @@
+// @ts-ignore -- generated on runtime
+import "./dist/index.js";
+
+// @ts-ignore -- generated on runtime
+import "./dist/instrumented.js";

--- a/test/fixtures/variable-declaration/sources.ts
+++ b/test/fixtures/variable-declaration/sources.ts
@@ -1,0 +1,15 @@
+var a = 1;
+
+var b;
+
+let c = 2;
+
+let d;
+
+const e = 3;
+
+b = 4;
+
+d;
+
+export { a, b, c, d, e };

--- a/test/statement-coverage.test.ts
+++ b/test/statement-coverage.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "vitest";
+
+import { test } from "./utils";
+
+test("variable declaration", async ({ actual, expected }) => {
+  expect(actual).toMatchInlineSnapshot(`
+    {
+      "branches": "0/0 (100%)",
+      "functions": "0/0 (100%)",
+      "lines": "4/4 (100%)",
+      "statements": "4/4 (100%)",
+    }
+  `);
+
+  expect(actual.statementMap).toMatchStatements(expected.statementMap);
+  expect(Object.keys(actual.s)).toEqual(Object.keys(expected.s));
+});


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/635c0b88-68c4-4d1c-ab4e-4e73b6afbcaa" width="400" />