### PR TITLE
fix: inline comment ignore hint detection

### DIFF
--- a/src/ignore-hints.ts
+++ b/src/ignore-hints.ts
@@ -48,10 +48,8 @@ export function getIgnoreHints(code: string): IgnoreHint[] {
         // End of multiline comment
         .replace(/\*\*\/$/, "")
         .replace(/\*\/$/, "")
-        // Start of inline comment
-        .replace(/^\/\//, "")
-        // End of inline comment
-        .replace(/\/\/$/, "");
+        // Inline comment
+        .replace(/^\/\//, "");
 
       const groups = comment.match(IGNORE_PATTERN);
       const type = groups?.[1];


### PR DESCRIPTION
No such thing as "end of inline comment". 