### PR TITLE
fix: find all leaves of nested `LogicalExpression`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,8 +154,8 @@ export default async function convert(options: {
     onConditionalExpression(node) {
       onBranch("cond-expr", node, [node.consequent, node.alternate]);
     },
-    onLogicalExpression(node) {
-      onBranch("binary-expr", node, [node.left, node.right]);
+    onLogicalExpression(node, branches) {
+      onBranch("binary-expr", node, branches);
     },
     onSwitchStatement(node) {
       onBranch("switch", node, node.cases);

--- a/test/branch-coverage.test.ts
+++ b/test/branch-coverage.test.ts
@@ -31,10 +31,10 @@ test("conditional expression", async ({ actual, expected }) => {
 test("logical-expression", async ({ actual, expected }) => {
   expect(actual).toMatchInlineSnapshot(`
     {
-      "branches": "5/8 (62.5%)",
+      "branches": "8/13 (61.53%)",
       "functions": "1/1 (100%)",
-      "lines": "5/5 (100%)",
-      "statements": "5/5 (100%)",
+      "lines": "8/8 (100%)",
+      "statements": "9/9 (100%)",
     }
   `);
 

--- a/test/fixtures/logical-expression/sources.ts
+++ b/test/fixtures/logical-expression/sources.ts
@@ -4,12 +4,21 @@ condition && noop();
 
 condition || noop();
 
-/* prettier-ignore */ /* @ts-expect-error */
+/* @ts-expect-error */
 condition === false &&
    noop();
 
-/* prettier-ignore */
 condition === true ||
    noop();
+
+let a = 1, b = 2;
+
+if (
+   a === 2 ||
+   b === 2 ||
+   a === b
+) {
+  noop();
+}
 
 function noop() {}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d6cf651a-ced0-4cde-8bd2-1e1b6b7df06a)
