### PR TITLE
perf: `offsetToNeedle` caching improvement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Bench
+        if: matrix.node-version == '22'
+        run: pnpm bench:ci
+
   publish-preview:
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "tsup --watch --sourcemap",
     "bench": "node --experimental-strip-types --cpu-prof --cpu-prof-dir=./bench-profile ./benchmark/run.ts",
+    "bench:ci": "node --experimental-strip-types ./benchmark/run.ts",
     "build": "tsup",
     "test": "vitest",
     "lint": "eslint . --max-warnings 0",

--- a/src/coverage-map.ts
+++ b/src/coverage-map.ts
@@ -77,8 +77,8 @@ export function addFunction(options: {
 
   fileCoverage.data.fnMap[meta.lastFunction] = {
     name: options.name || `(anonymous_${meta.lastFunction})`,
-    decl: pickLocation(options.decl),
-    loc: pickLocation(options.loc),
+    decl: options.decl,
+    loc: options.loc,
     line: options.loc.start.line,
   };
   fileCoverage.f[meta.lastFunction] = options.covered || 0;
@@ -95,9 +95,7 @@ export function addStatement(options: {
   const fileCoverage = options.coverageMap.fileCoverageFor(options.filename);
   const meta = (fileCoverage.data as FileCoverageDataWithMeta).meta;
 
-  fileCoverage.data.statementMap[meta.lastStatement] = pickLocation(
-    options.loc,
-  );
+  fileCoverage.data.statementMap[meta.lastStatement] = options.loc;
   fileCoverage.s[meta.lastStatement] = options.covered || 0;
 
   meta.lastStatement++;
@@ -115,21 +113,14 @@ export function addBranch(options: {
   const meta = (fileCoverage.data as FileCoverageDataWithMeta).meta;
 
   fileCoverage.data.branchMap[meta.lastBranch] = {
-    loc: pickLocation(options.loc),
+    loc: options.loc,
     type: options.type,
     // @ts-expect-error -- Istanbul cheats types for implicit else
-    locations: options.locations.map((loc) => pickLocation(loc)),
+    locations: options.locations,
     line: options.loc.start.line,
   };
   fileCoverage.b[meta.lastBranch] =
     options.covered || Array(options.locations.length).fill(0);
 
   meta.lastBranch++;
-}
-
-function pickLocation<T extends { start: Needle; end: Needle }>(original: T) {
-  return {
-    start: { line: original.start.line, column: original.start.column },
-    end: { line: original.end.line, column: original.end.column },
-  };
 }


### PR DESCRIPTION
- `checker.ts` goes from 60s to 1s

```
# Before:
Transforming took 1.83s
AST parsing took 0.15s
Coverage remapping took 59.66s

CoverageSummary {
  data: {
    lines: { total: 23198, covered: 0, skipped: 0, pct: 0 },
    statements: { total: 24054, covered: 0, skipped: 0, pct: 0 },
    functions: { total: 3267, covered: 0, skipped: 0, pct: 0 },
    branches: { total: 27805, covered: 0, skipped: 0, pct: 0 },
    branchesTrue: { total: 0, covered: 0, skipped: 0, pct: 'Unknown' }
  }
}

# After
Transforming took 2.05s
AST parsing took 0.14s
Coverage remapping took 1.00s

CoverageSummary {
  data: {
    lines: { total: 23198, covered: 0, skipped: 0, pct: 0 },
    statements: { total: 24054, covered: 0, skipped: 0, pct: 0 },
    functions: { total: 3267, covered: 0, skipped: 0, pct: 0 },
    branches: { total: 27805, covered: 0, skipped: 0, pct: 0 },
    branchesTrue: { total: 0, covered: 0, skipped: 0, pct: 'Unknown' }
  }
}
```



<img width="400" src="https://github.com/user-attachments/assets/7560fafd-869b-422e-8d7c-65202c2b37bb" />

<img width="400" src="https://github.com/user-attachments/assets/19da04b5-1513-4bf1-9859-984b465a411c" />

