### PR TITLE
fix!: output `CoverageMapData` instead of `CoverageMap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Passes all 195 tests<sup>[*](#istanbul-compatibility)</sup> of [`istanbul-lib-in
 ```ts
 import { convert } from "ast-v8-to-istanbul";
 import { parseAstAsync } from "vite";
-import type { CoverageMap } from "istanbul-lib-coverage";
+import type { CoverageMapData } from "istanbul-lib-coverage";
 
-const coverageMap: CoverageMap = await convert({
+const data: CoverageMapData = await convert({
   // Bring-your-own AST parser
   ast: parseAstAsync(<code>),
 

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { type EncodedSourceMap } from "@jridgewell/trace-mapping";
+import libCoverage from "istanbul-lib-coverage";
 import * as ts from "typescript";
 import { parseAstAsync } from "vite";
 
@@ -34,7 +35,7 @@ const coverage = await convert({
 });
 coverageTimer();
 
-console.log(coverage.getCoverageSummary());
+console.log(libCoverage.createCoverageMap(coverage).getCoverageSummary());
 
 async function transform(filename: Filename) {
   const directory = resolve(import.meta.dirname, "./fixtures");

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.25",
     "estree-walker": "^3.0.3",
-    "istanbul-lib-coverage": "^3.2.2",
     "js-tokens": "^9.0.1"
   },
   "devDependencies": {
@@ -49,6 +48,7 @@
     "eslint-plugin-import-x": "^4.6.1",
     "eslint-plugin-prettier": "^5.2.3",
     "eslint-plugin-unicorn": "^57.0.0",
+    "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-lib-source-maps": "^5.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
-      istanbul-lib-coverage:
-        specifier: ^3.2.2
-        version: 3.2.2
       js-tokens:
         specifier: ^9.0.1
         version: 9.0.1
@@ -66,6 +63,9 @@ importers:
       eslint-plugin-unicorn:
         specifier: ^57.0.0
         version: 57.0.0(eslint@9.21.0)
+      istanbul-lib-coverage:
+        specifier: ^3.2.2
+        version: 3.2.2
       istanbul-lib-instrument:
         specifier: ^6.0.3
         version: 6.0.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { type EncodedSourceMap, TraceMap } from "@jridgewell/trace-mapping";
 import type { Node } from "estree";
-import type { CoverageMap } from "istanbul-lib-coverage";
+import type { CoverageMapData } from "istanbul-lib-coverage";
 
 import { type FunctionNodes, getFunctionName, walk } from "./ast";
 import {
@@ -11,8 +11,7 @@ import {
   addFunction,
   addStatement,
   type Branch,
-  createCoverageMap,
-  createEmptyCoverageMap,
+  createCoverageMapData,
 } from "./coverage-map";
 import { getIgnoreHints } from "./ignore-hints";
 import { createEmptySourceMap, getInlineSourceMap, Locator } from "./location";
@@ -48,12 +47,12 @@ export default async function convert(options: {
     node: Node,
     type: "function" | "statement" | "branch",
   ) => boolean | void;
-}): Promise<CoverageMap> {
+}): Promise<CoverageMapData> {
   const ignoreHints = getIgnoreHints(options.code);
 
   // File ignore contains always only 1 entry
   if (ignoreHints.length === 1 && ignoreHints[0].type === "file") {
-    return createEmptyCoverageMap();
+    return {};
   }
 
   const wrapperLength = options.wrapperLength || 0;
@@ -67,7 +66,7 @@ export default async function convert(options: {
   );
   const locator = new Locator(options.code, map);
 
-  const coverageMap = createCoverageMap(filename, map);
+  const coverageMapData = createCoverageMapData(filename, map);
   const ranges = normalize(options.coverage);
   const ast = await options.ast;
 
@@ -180,7 +179,7 @@ export default async function convert(options: {
 
   locator.reset();
 
-  return coverageMap;
+  return coverageMapData;
 
   function onFunction(
     node: FunctionNodes,
@@ -206,7 +205,7 @@ export default async function convert(options: {
     );
 
     addFunction({
-      coverageMap,
+      coverageMapData,
       covered,
       loc,
       decl,
@@ -234,7 +233,7 @@ export default async function convert(options: {
     );
 
     addStatement({
-      coverageMap,
+      coverageMapData,
       loc,
       covered,
       filename: getSourceFilename(loc),
@@ -307,7 +306,7 @@ export default async function convert(options: {
     }
 
     addBranch({
-      coverageMap,
+      coverageMapData,
       loc,
       locations,
       type,

--- a/test/empty-coverage.test.ts
+++ b/test/empty-coverage.test.ts
@@ -1,5 +1,6 @@
 import { normalize, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { createCoverageMap } from "istanbul-lib-coverage";
 import MagicString from "magic-string";
 import { parseAstAsync } from "vite";
 import { expect, test } from "vitest";
@@ -21,7 +22,7 @@ export function second() {
   const code = s.toString();
   const sourceMap = s.generateMap({ hires: "boundary", file: filename });
 
-  const coverage = await convert({
+  const data = await convert({
     code,
     sourceMap,
     coverage: {
@@ -31,6 +32,7 @@ export function second() {
     ast: parseAstAsync(code),
   });
 
+  const coverage = createCoverageMap(data);
   expect(coverage.files()).toStrictEqual([filename]);
 
   expect(coverage).toMatchInlineSnapshot(`

--- a/test/ignore-node.test.ts
+++ b/test/ignore-node.test.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL } from "node:url";
+import { createCoverageMap } from "istanbul-lib-coverage";
 import { parseAstAsync } from "vite";
 import { expect, test } from "vitest";
 
@@ -42,7 +43,7 @@ Object.defineProperty(__vite_ssr_exports__, "uncovered", { enumerable: true, con
 `;
 
 test("ignoreNode can ignore Vite's imports", async () => {
-  const coverageMap = await convert({
+  const data = await convert({
     code,
     ast: parseAstAsync(code),
     coverage: { functions: [], url: pathToFileURL(sourceMap.file).href },
@@ -58,6 +59,7 @@ test("ignoreNode can ignore Vite's imports", async () => {
     },
   });
 
+  const coverageMap = createCoverageMap(data);
   const fileCoverage = coverageMap.fileCoverageFor(coverageMap.files()[0]);
 
   const lines = Object.keys(fileCoverage.getLineCoverage()).map((l) =>

--- a/test/istanbul-references.test.ts
+++ b/test/istanbul-references.test.ts
@@ -3,7 +3,7 @@ import { readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { type Profiler } from "node:inspector";
 import { normalize, resolve } from "node:path";
 import { Worker } from "node:worker_threads";
-import { type FileCoverage } from "istanbul-lib-coverage";
+import { createCoverageMap, type FileCoverage } from "istanbul-lib-coverage";
 import MagicString from "magic-string";
 import { parseAstAsync } from "vite";
 import { describe, expect, onTestFinished, test } from "vitest";
@@ -85,7 +85,7 @@ describe.each(suites)("$suite", async ({ tests }) => {
 
       await worker.terminate();
 
-      const coverageMap = await convert({
+      const data = await convert({
         code: t.code,
         coverage,
         ast: parseAstAsync(t.code),
@@ -102,6 +102,7 @@ describe.each(suites)("$suite", async ({ tests }) => {
 
       const message = `\nCode: \n\n${t.code}\n`;
 
+      const coverageMap = createCoverageMap(data);
       const isEmpty = coverageMap.files().length === 0;
       const fileCoverage = isEmpty
         ? ({} as FileCoverage)

--- a/test/source-maps.test.ts
+++ b/test/source-maps.test.ts
@@ -4,6 +4,7 @@ import { writeFile } from "node:fs/promises";
 import { normalize, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { createCoverageMap } from "istanbul-lib-coverage";
 import MagicString from "magic-string";
 import { parseAstAsync } from "vite";
 import { expect, onTestFinished, test } from "vitest";
@@ -42,7 +43,7 @@ export function uncovered() {
 }
 `).generateMap({ hires: "boundary", file: filename });
 
-  const coverage = await convert({
+  const data = await convert({
     code,
     sourceMap,
     coverage: {
@@ -68,6 +69,7 @@ export function uncovered() {
     ast: parseAstAsync(code),
   });
 
+  const coverage = createCoverageMap(data);
   const fileCoverage = coverage.fileCoverageFor(filename);
 
   expect(fileCoverage).toMatchInlineSnapshot(`
@@ -114,7 +116,7 @@ export function covered() {
 
   sourceMap.sources = [source.href];
 
-  const coverage = await convert({
+  const data = await convert({
     code,
     sourceMap,
     coverage: {
@@ -130,6 +132,7 @@ export function covered() {
     ast: parseAstAsync(code),
   });
 
+  const coverage = createCoverageMap(data);
   const fileCoverage = coverage.fileCoverageFor(fileURLToPath(source));
 
   expect(fileCoverage).toMatchInlineSnapshot(`
@@ -153,7 +156,7 @@ export function covered() {
 
   const code = s.toString();
 
-  const coverage = await convert({
+  const data = await convert({
     code,
     sourceMap: undefined,
     ast: parseAstAsync(code),
@@ -169,6 +172,7 @@ export function covered() {
     },
   });
 
+  const coverage = createCoverageMap(data);
   const fileCoverage = coverage.fileCoverageFor(filename);
 
   expect(fileCoverage).toMatchInlineSnapshot(`
@@ -217,7 +221,7 @@ test("inline source map as base64", async () => {
 
   code += `\n//# sourceMappingURL=data:application/json;base64,${encoded}\n`;
 
-  const coverage = await convert({
+  const data = await convert({
     code,
     sourceMap: undefined,
     ast: parseAstAsync(code),
@@ -233,6 +237,7 @@ test("inline source map as base64", async () => {
     },
   });
 
+  const coverage = createCoverageMap(data);
   const fileCoverage = coverage.fileCoverageFor(filename);
 
   expect(fileCoverage).toMatchInlineSnapshot(`
@@ -273,7 +278,7 @@ test("inline source map as filename", async () => {
 
   code += `\n//# sourceMappingURL=file-${uuid}.js.map\n`;
 
-  const coverage = await convert({
+  const data = await convert({
     code,
     sourceMap: undefined,
     ast: parseAstAsync(code),
@@ -289,6 +294,7 @@ test("inline source map as filename", async () => {
     },
   });
 
+  const coverage = createCoverageMap(data);
   const fileCoverage = coverage.fileCoverageFor(filename);
 
   expect(fileCoverage).toMatchInlineSnapshot(`

--- a/test/utils/test.ts
+++ b/test/utils/test.ts
@@ -28,7 +28,7 @@ export const test = base.extend<{
   },
 
   actual: async ({ fixture, debug, ignoreClassMethods }, use) => {
-    const coverageMap = await convert({
+    const data = await convert({
       ast: parseAstAsync(fixture.transpiled),
       code: fixture.transpiled,
       wrapperLength: 0,
@@ -37,9 +37,9 @@ export const test = base.extend<{
       ignoreClassMethods,
     });
 
-    const copy = createCoverageMap(JSON.parse(JSON.stringify(coverageMap)));
+    const copy = createCoverageMap(JSON.parse(JSON.stringify(data)));
 
-    const normalized = normalizeMap(coverageMap);
+    const normalized = normalizeMap(createCoverageMap(data));
     const isEmpty = normalized.files().length === 0;
     const actual = isEmpty
       ? ({} as any)


### PR DESCRIPTION
- Avoid shipping `istanbul-lib-coverage` so that `instanceof` checks of `coverageMap.merge()` don't fail in downstream projects
- The original `v8-to-istanbul` outputs `CoverageMapData` too