### PR TITLE
perf: optimize `getCount` by binary search

### DIFF
--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -14,7 +14,7 @@ type Filename =
   | "functions.ts"
   | (string & {});
 
-const filename: Filename = "checker.ts";
+const filename: Filename = process.argv[2] || 'checker.ts'
 
 const functions = await getFunctions(filename);
 

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -14,7 +14,7 @@ type Filename =
   | "functions.ts"
   | (string & {});
 
-const filename: Filename = process.argv[2] || 'checker.ts'
+const filename: Filename = process.argv[2] || "checker.ts";
 
 const functions = await getFunctions(filename);
 

--- a/src/script-coverage.ts
+++ b/src/script-coverage.ts
@@ -66,7 +66,10 @@ export function getCount(
     const mid = Math.floor((low + high) / 2);
     const coverage = coverages[mid];
 
-    if (coverage.start <= offset.startOffset && offset.startOffset <= coverage.end) {
+    if (
+      coverage.start <= offset.startOffset &&
+      offset.startOffset <= coverage.end
+    ) {
       return coverage.count;
     } else if (offset.startOffset < coverage.start) {
       high = mid - 1;

--- a/src/script-coverage.ts
+++ b/src/script-coverage.ts
@@ -59,25 +59,21 @@ export function getCount(
   offset: Pick<Profiler.CoverageRange, "startOffset" | "endOffset">,
   coverages: Normalized[],
 ) {
-  let closest: (Normalized & { diff: number }) | undefined = undefined;
+  let low = 0;
+  let high = coverages.length - 1;
 
-  for (const coverage of coverages) {
-    // Coverages should be sorted
-    if (coverage.start > offset.startOffset) {
-      continue;
-    }
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const coverage = coverages[mid];
 
-    const diff = Math.abs(coverage.start - offset.startOffset);
-
-    if (!closest) {
-      closest = { ...coverage, diff };
-      continue;
-    }
-
-    if (closest.diff > diff) {
-      closest = { ...coverage, diff };
+    if (coverage.start <= offset.startOffset && offset.startOffset <= coverage.end) {
+      return coverage.count;
+    } else if (offset.startOffset < coverage.start) {
+      high = mid - 1;
+    } else {
+      low = mid + 1;
     }
   }
 
-  return closest?.count || 0;
+  return 0;
 }


### PR DESCRIPTION
I was checking bench and it looks like `getLoc` and `getCount` is taking time due to linear search. I think you are already aware and did some optimization, but I'm wondering whether we should try binary search. I'm not sure if this is the bottleneck of actual use case though.

Here is the result of `functions.ts` bench after writing (asking copilot :face_with_peeking_eye:) `getCount` as binary search.

- before

```
$ pnpm bench functions.ts
...
Coverage remapping took 1.09s
```

![image](https://github.com/user-attachments/assets/289e5222-9caf-4107-8ed0-02169d819d2c)


- after

```
$ pnpm bench functions.ts
...
Coverage remapping took 0.72s
```

(somehow both `getCount` and `onBranch` disappeared from profile :thinking:)

![image](https://github.com/user-attachments/assets/fd71aaaf-fe90-4fc9-93c5-5dca47ff8791)
