### PR TITLE
test: transform fixtures with `oxc-transform`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "istanbul-reports": "^3.1.7",
     "magic-string": "^0.30.17",
     "oxc-parser": "^0.62.0",
+    "oxc-transform": "^0.63.0",
     "prettier": "^3.5.1",
     "rollup": "^4.32.1",
     "tinyrainbow": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       oxc-parser:
         specifier: ^0.62.0
         version: 0.62.0
+      oxc-transform:
+        specifier: ^0.63.0
+        version: 0.63.0
       prettier:
         specifier: ^3.5.1
         version: 3.5.2
@@ -659,6 +662,65 @@ packages:
 
   '@oxc-project/types@0.62.0':
     resolution: {integrity: sha512-rC3YQjrntGvg8vkHHKaiFqZFBCDU/F3BPfokssD02q5Sn4dSZGYzJVdojqYIEFECpEMEqKBxqIRmVex1+WXI5w==}
+
+  '@oxc-transform/binding-darwin-arm64@0.63.0':
+    resolution: {integrity: sha512-ZXFMAjIf1/D2lSpfMJribjm5X7TdLYUHqtHsaizsNQjXv111hDUkFvqtQT0uWMMn35VdyrJATGP/MNDCzD3zQg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.63.0':
+    resolution: {integrity: sha512-NJvBZcjBZNYXcpCbA+xB8efLbfc9SWAevs8vqJqBy6cO+DDCH1XULkzZm0zpZNE/T+sfUW5m9oYYntJl4hcxng==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.63.0':
+    resolution: {integrity: sha512-FFd6qyKvQoHt8OygRqvoS/7jsFmQqu0cjP4GpxRK3wD0JEnNBIWPA9m1cIG8h/0FEy66srvguHrLfDXqB1RTMw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.63.0':
+    resolution: {integrity: sha512-0TTyD6H6gndPEKIuOh0EyjybScF/i8josFIG0tnZdTOSXJcJ7qxEJtX8+UkrGWVf4aukrwe7tkjnBWiWg2kOxg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.63.0':
+    resolution: {integrity: sha512-rD9jm2C8qOTZJLTsIpNWkqcmvbHKpvwYY7oBKNo68l0uaNEviVAbOmhgSMmaSRoZnoaLZyUSs4dL3+jIlgDnmA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.63.0':
+    resolution: {integrity: sha512-ViFD67fOShiZb8uGXYHa10JgAJUCoEdiRq6Pkwo8G4/FpRQJiUk247ub6uHD2LzMI2mb77mzNz7hq44fVc+qMw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.63.0':
+    resolution: {integrity: sha512-TH/qhlBpQrh5rVH4mtFTin508dLztb+m6CKrs0xcJkg7maUeFFP5jwZLAfcgO6fyIwqZDAGh6xbKkatP+T2GKQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-wasm32-wasi@0.63.0':
+    resolution: {integrity: sha512-cjrNWd1pFZm0CmJVZ8AZ+CNWJBaQxQMuo9lbxuv9W4lo0gr0YI8zXYg8nzVo3GFuxrYyJWQs9Qy6FhXGEgmiJg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.63.0':
+    resolution: {integrity: sha512-KOtdkayxoUdAdDWCuzIECp2V5+aampT7y3FMyJ2pfRksLsfKZi/uv0sh/iGD8mbg9XFpt+NeySF+xDwu/VwKLg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.63.0':
+    resolution: {integrity: sha512-+Jg5/09KWhUEX/OBi266FxnJ2uHwVi9BJPzZffqXOHwb3OLrDo/EghIGbqvxU/xVVizV4h0AztdFXg9FzneBRw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1495,6 +1557,10 @@ packages:
 
   oxc-parser@0.62.0:
     resolution: {integrity: sha512-WwSVsS8e7KH8an4rQJJZuO2QiIxNA0ryPESmmdxy1KYRSKEscyBgbIGGv2lCWy3uTksQtAjB2s2YAohESfrfOQ==}
+    engines: {node: '>=14.0.0'}
+
+  oxc-transform@0.63.0:
+    resolution: {integrity: sha512-lmuGJ6pCDUSJ5iEF+P/GuMett0TRhwDl96vQxWRT5l3YqmgmO/idXYOgusxDOvxxx5eFi0OiZ6+9bWKf5XNZdQ==}
     engines: {node: '>=14.0.0'}
 
   p-limit@3.1.0:
@@ -2384,6 +2450,38 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.62.0': {}
+
+  '@oxc-transform/binding-darwin-arm64@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.63.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.8
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.63.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.63.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3279,6 +3377,19 @@ snapshots:
       '@oxc-parser/binding-wasm32-wasi': 0.62.0
       '@oxc-parser/binding-win32-arm64-msvc': 0.62.0
       '@oxc-parser/binding-win32-x64-msvc': 0.62.0
+
+  oxc-transform@0.63.0:
+    optionalDependencies:
+      '@oxc-transform/binding-darwin-arm64': 0.63.0
+      '@oxc-transform/binding-darwin-x64': 0.63.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.63.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.63.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.63.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.63.0
+      '@oxc-transform/binding-linux-x64-musl': 0.63.0
+      '@oxc-transform/binding-wasm32-wasi': 0.63.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.63.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.63.0
 
   p-limit@3.1.0:
     dependencies:


### PR DESCRIPTION
- `oxc-transform` added support for coverage hints in https://github.com/oxc-project/oxc/issues/10091, we can now run tests using oxc.