### PR TITLE
fix: `ignore else` for implicit else

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -265,7 +265,7 @@ export function getWalker() {
 
             if (hint === "else" && node.alternate) {
               setSkipped(node.alternate);
-            } else if (hint !== "if") {
+            } else if (hint !== "if" && hint !== "else") {
               branches.push(node.alternate);
             }
 

--- a/test/fixtures/ignore-if-else/sources.ts
+++ b/test/fixtures/ignore-if-else/sources.ts
@@ -21,3 +21,11 @@ if (truthy) {
   }
   uncovered_2();
 }
+
+/* istanbul ignore else -- @preserve */
+if (truthy) {
+  function covered_2() {
+    return "covered but implicit else ignored";
+  }
+  covered_2();
+}

--- a/test/ignored-coverage.test.ts
+++ b/test/ignored-coverage.test.ts
@@ -24,10 +24,10 @@ test("ignore next", async ({ actual, expected }) => {
 test("ignore if else", async ({ actual, expected }) => {
   expect(actual).toMatchInlineSnapshot(`
     {
-      "branches": "1/1 (100%)",
-      "functions": "1/1 (100%)",
-      "lines": "7/7 (100%)",
-      "statements": "8/8 (100%)",
+      "branches": "2/2 (100%)",
+      "functions": "2/2 (100%)",
+      "lines": "11/11 (100%)",
+      "statements": "13/13 (100%)",
     }
   `);
 


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/8497

Before on left, after on right. See line 29-32:

<img width="600"  src="https://github.com/user-attachments/assets/f494741d-04c8-489a-ac91-6a1c6f86dc85" />
