### PR TITLE
fix: windows end-of-line

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -46,20 +46,15 @@ export class Locator {
     let column = cacheHit?.column ?? 0;
 
     for (let i = current; i <= this.#codeParts.length; i++) {
-      const char = this.#codeParts[i];
-
       if (current === offset) {
         return { line, column };
-      }
-
-      // Handle \r\n EOLs on next iteration
-      if (char === "\r") {
-        continue;
       }
 
       if (current % CACHE_THRESHOLD === 0) {
         this.#cache.set(current, { line, column });
       }
+
+      const char = this.#codeParts[i];
 
       if (char === "\n") {
         line++;

--- a/test/file-end-of-line.test.ts
+++ b/test/file-end-of-line.test.ts
@@ -1,0 +1,92 @@
+import { normalize, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createCoverageMap } from "istanbul-lib-coverage";
+import { expect, test } from "vitest";
+
+import convert from "../src";
+import { parse } from "./utils";
+
+test("source map is optional", async () => {
+  const filename = normalize(resolve("/some/file.ts"));
+
+  const code = `\
+function covered() {
+    return "covered";
+}
+
+function uncovered() {
+    return "uncovered";
+}
+
+covered();
+covered();
+  `
+    .split("\n")
+    .join("\r\n");
+
+  const data = await convert({
+    code,
+    sourceMap: undefined,
+    ast: parse(code),
+    coverage: {
+      url: pathToFileURL(filename).href,
+
+      // Captured from actual Windows machine with Node v22.13.0
+      functions: [
+        {
+          functionName: "",
+          ranges: [{ startOffset: 0, endOffset: 128, count: 1 }],
+          isBlockCoverage: true,
+        },
+        {
+          functionName: "covered",
+          ranges: [{ startOffset: 0, endOffset: 46, count: 2 }],
+          isBlockCoverage: true,
+        },
+        {
+          functionName: "uncovered",
+          ranges: [{ startOffset: 50, endOffset: 100, count: 0 }],
+          isBlockCoverage: false,
+        },
+      ],
+    },
+  });
+
+  const coverage = createCoverageMap(data);
+  const fileCoverage = coverage.fileCoverageFor(filename);
+
+  expect(fileCoverage).toMatchInlineSnapshot(`
+    {
+      "branches": "0/0 (100%)",
+      "functions": "1/2 (50%)",
+      "lines": "3/4 (75%)",
+      "statements": "3/4 (75%)",
+    }
+  `);
+
+  const lineCoverage = fileCoverage.getLineCoverage();
+
+  const lines = code.split("\r\n").map((row, index) => {
+    const coverage = lineCoverage[index + 1];
+    const marker = coverage != null ? `${coverage}x` : "  ";
+
+    return `${marker} | ${row}`.trimEnd();
+  });
+
+  expect(["", ...lines, ""].join("\n")).toMatchInlineSnapshot(`
+    "
+       | function covered() {
+    2x |     return "covered";
+       | }
+       |
+       | function uncovered() {
+    0x |     return "uncovered";
+       | }
+       |
+    1x | covered();
+    1x | covered();
+       |
+    "
+  `);
+});

--- a/test/location.test.ts
+++ b/test/location.test.ts
@@ -96,6 +96,9 @@ function sum(a, b) {
     "",
   );
 
-  expect(locator.offsetToNeedle(58)).toEqual({ line: 2, column: 9 });
-  expect(locator.offsetToNeedle(61)).toEqual({ line: 2, column: 12 });
+  const start = code.indexOf("sum");
+  const end = start + "sum".length;
+
+  expect(locator.offsetToNeedle(start)).toEqual({ line: 2, column: 9 });
+  expect(locator.offsetToNeedle(end)).toEqual({ line: 2, column: 12 });
 });


### PR DESCRIPTION
- Closes #96
- Fixes #95

Added test case from real Windows machine. The `\r\n` seems to count as `2` in `ScriptCoverage` and AST node's locations.
