### PR TITLE
fix: source map with multiple sources may fail in `getSourceLines`

### DIFF
--- a/src/location.ts
+++ b/src/location.ts
@@ -145,7 +145,8 @@ export class Locator {
 
   getSourceLines(loc: { start: Needle; end: Needle }, filename: string) {
     const index = this.#map.resolvedSources.findIndex(
-      (source) => source === filename || resolve(this.#directory, source),
+      (source) =>
+        source === filename || resolve(this.#directory, source) === filename,
     );
     const sourcesContent = this.#map.sourcesContent?.[index];
 


### PR DESCRIPTION
Addresses https://github.com/AriPerkkio/ast-v8-to-istanbul/pull/109#pullrequestreview-3579942294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the wrong source location could be selected due to path resolution inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->