### PR TITLE
refactor: split entrypoint to `CoverageMapper`

### DIFF
--- a/src/coverage-map.ts
+++ b/src/coverage-map.ts
@@ -14,7 +14,7 @@ export type Branch =
   | "switch"
   | "default-arg";
 
-type CoverageMapData = IstanbulCoverageMapData & {
+export type CoverageMapData = IstanbulCoverageMapData & {
   [key: string]: FileCoverageData;
 };
 

--- a/src/coverage-mapper.ts
+++ b/src/coverage-mapper.ts
@@ -1,0 +1,276 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { TraceMap } from "@jridgewell/trace-mapping";
+import { type Node } from "estree";
+
+import { type FunctionNodes, getFunctionName, type getWalker } from "./ast";
+import {
+  addBranch,
+  addFunction,
+  addStatement,
+  type Branch,
+  type CoverageMapData,
+  createCoverageMapData,
+} from "./coverage-map";
+import { createEmptySourceMap, getInlineSourceMap, Locator } from "./location";
+import { getCount, normalize } from "./script-coverage";
+import type { Options } from "./types";
+
+type Normalized = ReturnType<typeof normalize>;
+
+export class CoverageMapper<T = Node> {
+  private constructor(
+    private locator: Locator,
+    private coverageMapData: CoverageMapData,
+    private ranges: Normalized,
+    private wrapperLength: number,
+    private directory: string,
+    private onIgnoreNode: ReturnType<typeof getWalker>["onIgnore"],
+    private ignoreNode?: Options<T>["ignoreNode"],
+    private ignoreSourceCode?: Options<T>["ignoreSourceCode"],
+  ) {}
+
+  static async create<T = Node, Program = T & { type: "Program" }>(
+    options: Options<T, Program>,
+    onIgnoreNode: ReturnType<typeof getWalker>["onIgnore"],
+  ): Promise<CoverageMapper<T>> {
+    const filename = fileURLToPath(options.coverage.url);
+    const directory = dirname(filename);
+
+    const map = new TraceMap(
+      (options.sourceMap as typeof options.sourceMap & { version: 3 }) ||
+        (await getInlineSourceMap(filename, options.code)) ||
+        createEmptySourceMap(filename, options.code),
+    );
+
+    return new CoverageMapper<T>(
+      new Locator(options.code, map, directory),
+      createCoverageMapData(filename, map),
+      normalize(options.coverage),
+      options.wrapperLength || 0,
+      directory,
+      onIgnoreNode,
+      options.ignoreNode,
+      options.ignoreSourceCode,
+    );
+  }
+
+  onFunction(
+    node: FunctionNodes,
+    positions: {
+      loc: Pick<Node, "start" | "end">;
+      decl: Pick<Node, "start" | "end">;
+    },
+  ) {
+    if (this.#onIgnore(node, "function")) {
+      return;
+    }
+
+    const loc = this.locator.getLoc(positions.loc);
+    if (loc === null) return;
+
+    const decl = this.locator.getLoc(positions.decl);
+    if (decl === null) return;
+
+    const covered = getCount(
+      {
+        startOffset: node.start + this.wrapperLength,
+        endOffset: node.end + this.wrapperLength,
+      },
+      this.ranges,
+    );
+
+    if (this.ignoreSourceCode) {
+      const current = this.locator.getLoc(node) || loc;
+      const sources = this.locator.getSourceLines(
+        current,
+        this.#getSourceFilename(current),
+      );
+
+      if (
+        sources != null &&
+        this.ignoreSourceCode(sources, "function", {
+          start: { line: current.start.line, column: current.start.column },
+          end: { line: current.end.line, column: current.end.column },
+        })
+      ) {
+        return;
+      }
+    }
+
+    addFunction({
+      coverageMapData: this.coverageMapData,
+      covered,
+      loc,
+      decl,
+      filename: this.#getSourceFilename(loc),
+      name: getFunctionName(node),
+    });
+  }
+
+  onStatement(node: Node, parent?: Node) {
+    if (this.#onIgnore(parent || node, "statement")) {
+      return;
+    }
+
+    const loc = this.locator.getLoc(node);
+    if (loc === null) return;
+
+    const covered = getCount(
+      {
+        startOffset: (parent || node).start + this.wrapperLength,
+        endOffset: (parent || node).end + this.wrapperLength,
+      },
+      this.ranges,
+    );
+
+    if (this.ignoreSourceCode) {
+      const current = (parent && this.locator.getLoc(parent)) || loc;
+      const sources = this.locator.getSourceLines(
+        current,
+        this.#getSourceFilename(current),
+      );
+
+      if (
+        sources != null &&
+        this.ignoreSourceCode(sources, "statement", {
+          start: { line: current.start.line, column: current.start.column },
+          end: { line: current.end.line, column: current.end.column },
+        })
+      ) {
+        return;
+      }
+    }
+
+    addStatement({
+      coverageMapData: this.coverageMapData,
+      loc,
+      covered,
+      filename: this.#getSourceFilename(loc),
+    });
+  }
+
+  onBranch(type: Branch, node: Node, branches: (Node | null | undefined)[]) {
+    if (this.#onIgnore(node, "branch")) {
+      return;
+    }
+
+    const loc = this.locator.getLoc(node);
+    if (loc === null) return;
+
+    const locations = [];
+    const covered: number[] = [];
+
+    for (const branch of branches) {
+      if (!branch) {
+        locations.push({
+          start: { line: undefined, column: undefined },
+          end: { line: undefined, column: undefined },
+        });
+
+        const count = getCount(
+          {
+            startOffset: node.start + this.wrapperLength,
+            endOffset: node.end + this.wrapperLength,
+          },
+          this.ranges,
+        );
+        const previous = covered.at(-1) || 0;
+        covered.push(count - previous);
+
+        continue;
+      }
+
+      const location = this.locator.getLoc(branch);
+      if (location !== null) {
+        locations.push(location);
+      }
+
+      const bias = branch.type === "BlockStatement" ? 1 : 0;
+
+      covered.push(
+        getCount(
+          {
+            startOffset: branch.start + bias + this.wrapperLength,
+            endOffset: branch.end - bias + this.wrapperLength,
+          },
+          this.ranges,
+        ),
+      );
+    }
+
+    if (type === "if") {
+      if (locations.length > 0) {
+        locations[0] = loc;
+      }
+    }
+
+    if (locations.length === 0) {
+      return;
+    }
+
+    if (this.ignoreSourceCode) {
+      const sources = this.locator.getSourceLines(
+        loc,
+        this.#getSourceFilename(loc),
+      );
+
+      if (
+        sources != null &&
+        this.ignoreSourceCode(sources, "branch", {
+          start: { line: loc.start.line, column: loc.start.column },
+          end: { line: loc.end.line, column: loc.end.column },
+        })
+      ) {
+        return;
+      }
+    }
+
+    addBranch({
+      coverageMapData: this.coverageMapData,
+      loc,
+      locations,
+      type,
+      covered,
+      filename: this.#getSourceFilename(loc),
+    });
+  }
+
+  generate(): CoverageMapData {
+    this.locator.reset();
+    return this.coverageMapData;
+  }
+
+  #getSourceFilename(position: {
+    start: { filename: string | null };
+    end: { filename: string | null };
+  }) {
+    const sourceFilename = position.start.filename || position.end.filename;
+
+    if (!sourceFilename) {
+      throw new Error(
+        `Missing original filename for ${JSON.stringify(position, null, 2)}`,
+      );
+    }
+
+    if (sourceFilename.startsWith("file://")) {
+      return fileURLToPath(sourceFilename);
+    }
+
+    return resolve(this.directory, sourceFilename);
+  }
+
+  #onIgnore(node: Node, type: "function" | "statement" | "branch") {
+    if (!this.ignoreNode) {
+      return false;
+    }
+
+    const scope = this.ignoreNode(node as T, type);
+
+    if (scope === "ignore-this-and-nested-nodes") {
+      this.onIgnoreNode(node);
+    }
+
+    return scope;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,12 @@
-import type { Profiler } from "node:inspector";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { type EncodedSourceMap, TraceMap } from "@jridgewell/trace-mapping";
 import { type Node } from "estree";
 import type { CoverageMapData } from "istanbul-lib-coverage";
 
-import { type FunctionNodes, getFunctionName, getWalker } from "./ast";
-import {
-  addBranch,
-  addFunction,
-  addStatement,
-  type Branch,
-  createCoverageMapData,
-} from "./coverage-map";
+import { getWalker } from "./ast";
+import { CoverageMapper } from "./coverage-mapper";
 import { getIgnoreHints } from "./ignore-hints";
-import { createEmptySourceMap, getInlineSourceMap, Locator } from "./location";
-import { getCount, normalize } from "./script-coverage";
+import { type Options } from "./types";
 
-export { convert };
+export { convert, Options };
 
 /**
  * Maps V8 `ScriptCoverage` to Istanbul's `CoverageMap`.
@@ -26,41 +15,7 @@ export { convert };
 export default async function convert<
   T = Node,
   Program = T & { type: "Program" },
->(options: {
-  /** Code of the executed runtime file, not the original source file */
-  code: string;
-
-  /** Length of the execution wrapper, e.g. wrapper used in node:vm */
-  wrapperLength?: number;
-
-  /** Source map for the current file */
-  sourceMap?: Omit<EncodedSourceMap, "version"> & { version: number };
-
-  /** ScriptCoverage for the current file */
-  coverage: Pick<Profiler.ScriptCoverage, "functions" | "url">;
-
-  /** AST for the transpiled file that matches the coverage results */
-  ast: Program | Promise<Program>;
-
-  /** Class method names to ignore for coverage, identical to https://github.com/istanbuljs/nyc?tab=readme-ov-file#ignoring-methods */
-  ignoreClassMethods?: string[];
-
-  /** Filter to ignore code based on AST nodes */
-  ignoreNode?: (
-    node: T,
-    type: "function" | "statement" | "branch",
-  ) => boolean | "ignore-this-and-nested-nodes" | void;
-
-  /**
-   * Filter to ignore code based on source code
-   * - Note that this is slower than `ignoreNode` as exclusion happens after remapping
-   */
-  ignoreSourceCode?: (
-    code: string,
-    type: "function" | "statement" | "branch",
-    location: Record<"start" | "end", { line: number; column: number }>,
-  ) => boolean | void;
-}): Promise<CoverageMapData> {
+>(options: Options<T, Program>): Promise<CoverageMapData> {
   const ignoreHints = getIgnoreHints(options.code);
 
   // File ignore contains always only 1 entry
@@ -68,27 +23,17 @@ export default async function convert<
     return {};
   }
 
-  const wrapperLength = options.wrapperLength || 0;
-  const filename = fileURLToPath(options.coverage.url);
-  const directory = dirname(filename);
-
-  const map = new TraceMap(
-    (options.sourceMap as typeof options.sourceMap & { version: 3 }) ||
-      (await getInlineSourceMap(filename, options.code)) ||
-      createEmptySourceMap(filename, options.code),
-  );
-  const locator = new Locator(options.code, map, directory);
-
-  const coverageMapData = createCoverageMapData(filename, map);
-  const ranges = normalize(options.coverage);
-  const ast = await options.ast;
-
   const walker = getWalker();
+  const mapper = await CoverageMapper.create<T, Program>(
+    options,
+    walker.onIgnore,
+  );
+  const ast = await options.ast;
 
   await walker.walk(ast, ignoreHints, options.ignoreClassMethods, {
     // Functions
     onFunctionDeclaration(node) {
-      onFunction(node, {
+      mapper.onFunction(node, {
         loc: node.body,
         decl: node.id || { ...node, end: node.start + 1 },
       });
@@ -98,20 +43,20 @@ export default async function convert<
         return;
       }
 
-      onFunction(node, {
+      mapper.onFunction(node, {
         loc: node.body,
         decl: node.id || { ...node, end: node.start + 1 },
       });
     },
     onArrowFunctionExpression(node) {
-      onFunction(node, {
+      mapper.onFunction(node, {
         loc: node.body,
         decl: { ...node, end: node.start + 1 },
       });
 
       // Implicit return-statement of bodyless arrow function
       if (node.body.type !== "BlockStatement") {
-        onStatement(node.body, node);
+        mapper.onStatement(node.body, node);
       }
     },
     onMethodDefinition(node) {
@@ -119,7 +64,7 @@ export default async function convert<
         setCovered(node.value);
       }
 
-      onFunction(node, {
+      mapper.onFunction(node, {
         loc: node.value.body,
         decl: node.key,
       });
@@ -128,7 +73,7 @@ export default async function convert<
       if (node.value.type === "FunctionExpression") {
         setCovered(node.value);
 
-        onFunction(node, {
+        mapper.onFunction(node, {
           loc: node.value.body,
           decl: node.key,
         });
@@ -148,7 +93,7 @@ export default async function convert<
         params: [],
       };
 
-      onFunction(node, {
+      mapper.onFunction(node, {
         loc: node.body,
         decl: {
           start: babelNode.key.start!,
@@ -171,7 +116,7 @@ export default async function convert<
         params: [],
       };
 
-      onFunction(node, {
+      mapper.onFunction(node, {
         loc: node.body,
         decl: {
           start: babelNode.key.start!,
@@ -181,19 +126,19 @@ export default async function convert<
     },
 
     // Statements
-    onBreakStatement: onStatement,
-    onContinueStatement: onStatement,
-    onDebuggerStatement: onStatement,
-    onReturnStatement: onStatement,
-    onThrowStatement: onStatement,
-    onTryStatement: onStatement,
-    onForStatement: onStatement,
-    onForInStatement: onStatement,
-    onForOfStatement: onStatement,
-    onWhileStatement: onStatement,
-    onDoWhileStatement: onStatement,
-    onWithStatement: onStatement,
-    onLabeledStatement: onStatement,
+    onBreakStatement: (node) => mapper.onStatement(node),
+    onContinueStatement: (node) => mapper.onStatement(node),
+    onDebuggerStatement: (node) => mapper.onStatement(node),
+    onReturnStatement: (node) => mapper.onStatement(node),
+    onThrowStatement: (node) => mapper.onStatement(node),
+    onTryStatement: (node) => mapper.onStatement(node),
+    onForStatement: (node) => mapper.onStatement(node),
+    onForInStatement: (node) => mapper.onStatement(node),
+    onForOfStatement: (node) => mapper.onStatement(node),
+    onWhileStatement: (node) => mapper.onStatement(node),
+    onDoWhileStatement: (node) => mapper.onStatement(node),
+    onWithStatement: (node) => mapper.onStatement(node),
+    onLabeledStatement: (node) => mapper.onStatement(node),
     onExpressionStatement(node) {
       if (
         node.expression.type === "Literal" &&
@@ -202,11 +147,11 @@ export default async function convert<
         return;
       }
 
-      onStatement(node);
+      mapper.onStatement(node);
     },
     onVariableDeclarator(node) {
       if (node.init) {
-        onStatement(node.init, node);
+        mapper.onStatement(node.init, node);
       }
     },
     onClassBody(node) {
@@ -217,249 +162,32 @@ export default async function convert<
             child.type === "ClassPrivateProperty") &&
           child.value
         ) {
-          onStatement(child.value as Node);
+          mapper.onStatement(child.value as Node);
         }
       }
     },
 
     // Branches
     onIfStatement(node, branches) {
-      onBranch("if", node, branches);
-      onStatement(node);
+      mapper.onBranch("if", node, branches);
+      mapper.onStatement(node);
     },
     onConditionalExpression(node, branches) {
-      onBranch("cond-expr", node, branches);
+      mapper.onBranch("cond-expr", node, branches);
     },
     onLogicalExpression(node, branches) {
-      onBranch("binary-expr", node, branches);
+      mapper.onBranch("binary-expr", node, branches);
     },
     onSwitchStatement(node, cases) {
-      onBranch("switch", node, cases);
-      onStatement(node);
+      mapper.onBranch("switch", node, cases);
+      mapper.onStatement(node);
     },
     onAssignmentPattern(node) {
-      onBranch("default-arg", node, [node.right]);
+      mapper.onBranch("default-arg", node, [node.right]);
     },
   });
 
-  locator.reset();
-
-  return coverageMapData;
-
-  function onFunction(
-    node: FunctionNodes,
-    positions: {
-      loc: Pick<Node, "start" | "end">;
-      decl: Pick<Node, "start" | "end">;
-    },
-  ) {
-    if (onIgnore(node, "function")) {
-      return;
-    }
-
-    const loc = locator.getLoc(positions.loc);
-    if (loc === null) return;
-
-    const decl = locator.getLoc(positions.decl);
-    if (decl === null) return;
-
-    const covered = getCount(
-      {
-        startOffset: node.start + wrapperLength,
-        endOffset: node.end + wrapperLength,
-      },
-      ranges,
-    );
-
-    if (options.ignoreSourceCode) {
-      const current = locator.getLoc(node) || loc;
-      const sources = locator.getSourceLines(
-        current,
-        getSourceFilename(current),
-      );
-
-      if (
-        sources != null &&
-        options.ignoreSourceCode(sources, "function", {
-          start: { line: current.start.line, column: current.start.column },
-          end: { line: current.end.line, column: current.end.column },
-        })
-      ) {
-        return;
-      }
-    }
-
-    addFunction({
-      coverageMapData,
-      covered,
-      loc,
-      decl,
-      filename: getSourceFilename(loc),
-      name: getFunctionName(node),
-    });
-  }
-
-  function onStatement(node: Node, parent?: Node) {
-    if (onIgnore(parent || node, "statement")) {
-      return;
-    }
-
-    const loc = locator.getLoc(node);
-    if (loc === null) return;
-
-    const covered = getCount(
-      {
-        startOffset: (parent || node).start + wrapperLength,
-        endOffset: (parent || node).end + wrapperLength,
-      },
-      ranges,
-    );
-
-    if (options.ignoreSourceCode) {
-      const current = (parent && locator.getLoc(parent)) || loc;
-      const sources = locator.getSourceLines(
-        current,
-        getSourceFilename(current),
-      );
-
-      if (
-        sources != null &&
-        options.ignoreSourceCode(sources, "statement", {
-          start: { line: current.start.line, column: current.start.column },
-          end: { line: current.end.line, column: current.end.column },
-        })
-      ) {
-        return;
-      }
-    }
-
-    addStatement({
-      coverageMapData,
-      loc,
-      covered,
-      filename: getSourceFilename(loc),
-    });
-  }
-
-  function onBranch(
-    type: Branch,
-    node: Node,
-    branches: (Node | null | undefined)[],
-  ) {
-    if (onIgnore(node, "branch")) {
-      return;
-    }
-
-    const loc = locator.getLoc(node);
-    if (loc === null) return;
-
-    const locations = [];
-    const covered: number[] = [];
-
-    for (const branch of branches) {
-      if (!branch) {
-        locations.push({
-          start: { line: undefined, column: undefined },
-          end: { line: undefined, coolumn: undefined },
-        });
-
-        const count = getCount(
-          {
-            startOffset: node.start + wrapperLength,
-            endOffset: node.end + wrapperLength,
-          },
-          ranges,
-        );
-        const previous = covered.at(-1) || 0;
-        covered.push(count - previous);
-
-        continue;
-      }
-
-      const location = locator.getLoc(branch);
-      if (location !== null) {
-        locations.push(location);
-      }
-
-      const bias = branch.type === "BlockStatement" ? 1 : 0;
-
-      covered.push(
-        getCount(
-          {
-            startOffset: branch.start + bias + wrapperLength,
-            endOffset: branch.end - bias + wrapperLength,
-          },
-          ranges,
-        ),
-      );
-    }
-
-    if (type === "if") {
-      if (locations.length > 0) {
-        locations[0] = loc;
-      }
-    }
-
-    if (locations.length === 0) {
-      return;
-    }
-
-    if (options.ignoreSourceCode) {
-      const sources = locator.getSourceLines(loc, getSourceFilename(loc));
-
-      if (
-        sources != null &&
-        options.ignoreSourceCode(sources, "branch", {
-          start: { line: loc.start.line, column: loc.start.column },
-          end: { line: loc.end.line, column: loc.end.column },
-        })
-      ) {
-        return;
-      }
-    }
-
-    addBranch({
-      coverageMapData,
-      loc,
-      locations,
-      type,
-      covered,
-      filename: getSourceFilename(loc),
-    });
-  }
-
-  function getSourceFilename(position: {
-    start: { filename: string | null };
-    end: { filename: string | null };
-  }) {
-    const sourceFilename = position.start.filename || position.end.filename;
-
-    if (!sourceFilename) {
-      throw new Error(
-        `Missing original filename for ${JSON.stringify(position, null, 2)}`,
-      );
-    }
-
-    if (sourceFilename.startsWith("file://")) {
-      return fileURLToPath(sourceFilename);
-    }
-
-    return resolve(directory, sourceFilename);
-  }
-
-  function onIgnore(node: Node, type: "function" | "statement" | "branch") {
-    if (!options.ignoreNode) {
-      return false;
-    }
-
-    const scope = options.ignoreNode(node as T, type);
-
-    if (scope === "ignore-this-and-nested-nodes") {
-      walker.onIgnore(node);
-    }
-
-    return scope;
-  }
+  return mapper.generate();
 }
 
 const coveredNodes = new WeakSet<Node>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,39 @@
+import type { Profiler } from "node:inspector";
+import { type EncodedSourceMap } from "@jridgewell/trace-mapping";
+import { type Node } from "estree";
+
+export interface Options<T = Node, Program = T & { type: "Program" }> {
+  /** Code of the executed runtime file, not the original source file */
+  code: string;
+
+  /** Length of the execution wrapper, e.g. wrapper used in node:vm */
+  wrapperLength?: number;
+
+  /** Source map for the current file */
+  sourceMap?: Omit<EncodedSourceMap, "version"> & { version: number };
+
+  /** ScriptCoverage for the current file */
+  coverage: Pick<Profiler.ScriptCoverage, "functions" | "url">;
+
+  /** AST for the transpiled file that matches the coverage results */
+  ast: Program | Promise<Program>;
+
+  /** Class method names to ignore for coverage, identical to https://github.com/istanbuljs/nyc?tab=readme-ov-file#ignoring-methods */
+  ignoreClassMethods?: string[];
+
+  /** Filter to ignore code based on AST nodes */
+  ignoreNode?: (
+    node: T,
+    type: "function" | "statement" | "branch",
+  ) => boolean | "ignore-this-and-nested-nodes" | void;
+
+  /**
+   * Filter to ignore code based on source code
+   * - Note that this is slower than `ignoreNode` as exclusion happens after remapping
+   */
+  ignoreSourceCode?: (
+    code: string,
+    type: "function" | "statement" | "branch",
+    location: Record<"start" | "end", { line: number; column: number }>,
+  ) => boolean | void;
+}


### PR DESCRIPTION
Splits bloated `index.ts` entrypoint to separate `CoverageMapper`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported `Options` type for unified configuration of coverage mapping and filtering
  * Exported `CoverageMapData` type for public use

* **Refactor**
  * Extracted inline options type to separate `Options<T, Program>` type for improved code organization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->