### PR TITLE
fix: invalid d.ts in `types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "type": "module",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "exports": "./dist/index.mjs",
   "scripts": {
     "dev": "tsdown --watch --sourcemap",


### PR DESCRIPTION
Noticed this while looking at source in https://npmx.dev/code/ast-v8-to-istanbul/v/0.3.10/package.json

<img width="600" src="https://github.com/user-attachments/assets/6dba90fb-1afc-4c75-8065-af4e85dc306f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type declaration export configuration to ensure proper type information distribution across module environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->