### PR TITLE
fix: handle mismatch between source maps and coverage data

### DIFF
--- a/src/coverage-map.ts
+++ b/src/coverage-map.ts
@@ -147,7 +147,9 @@ export function addBranch(options: {
   }
 
   options.covered?.forEach((hit, i) => {
-    fileCoverage.b[index][i] += hit;
+    if (fileCoverage.b[index][i] !== undefined) {
+      fileCoverage.b[index][i] += hit;
+    }
   });
 }
 

--- a/test/source-maps.test.ts
+++ b/test/source-maps.test.ts
@@ -367,5 +367,11 @@ true === true
   const coverage = createCoverageMap(data);
   const fileCoverage = coverage.fileCoverageFor(filename);
 
-  expect(fileCoverage.b[0]).toEqual([1, 0]);
+  expect(fileCoverage.b).toMatchInlineSnapshot(`
+    {
+      "0": [
+        1,
+      ],
+    }
+  `);
 });


### PR DESCRIPTION
- Fixes https://github.com/vitest-dev/vitest/issues/9725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented undefined values from being recorded in branch hit counts, improving accuracy of coverage reports.

* **Tests**
  * Added a test for branch coverage with partially aligned source maps to validate correct branch visitation reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->