### PR TITLE
Clamp branch counts to minimum 0

### DIFF
--- a/src/coverage-mapper.ts
+++ b/src/coverage-mapper.ts
@@ -170,7 +170,7 @@ export class CoverageMapper<T = Node> {
           this.ranges,
         );
         const previous = covered.at(-1) || 0;
-        covered.push(count - previous);
+        covered.push(Math.max(0, count - previous));
 
         continue;
       }

--- a/test/negative-branch-count.test.ts
+++ b/test/negative-branch-count.test.ts
@@ -1,0 +1,38 @@
+import { normalize, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createCoverageMap } from "istanbul-lib-coverage";
+import { expect, test } from "vitest";
+
+import convert from "../src";
+import { parse } from "./utils";
+
+test("implicit else branch count is not negative", async () => {
+  const filename = normalize(resolve("/some/file.ts"));
+  const code = "if (a) b\n";
+  const data = await convert({
+    code,
+    ast: parse(code),
+    coverage: {
+      url: pathToFileURL(filename).href,
+      functions: [
+        {
+          functionName: "",
+          ranges: [
+            { startOffset: 0, endOffset: code.length, count: 1 },
+            { startOffset: 7, endOffset: 8, count: 100 },
+          ],
+          isBlockCoverage: true,
+        },
+      ],
+    },
+  });
+
+  const fileCoverage = createCoverageMap(data).fileCoverageFor(filename);
+
+  for (const [key, counts] of Object.entries(fileCoverage.b)) {
+    for (const count of counts) {
+      expect(count, `branch ${key} has negative count`).toBeGreaterThanOrEqual(0);
+    }
+  }
+});


### PR DESCRIPTION
Addresses #148 by disallowing negative counts to propagate from branches in the `coverage-mapper.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where coverage branch counts could incorrectly become negative in certain scenarios.

* **Tests**
  * Added test to verify branch coverage counts remain non-negative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->