### PR TITLE
fix: resolve class and object method names

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -364,6 +364,10 @@ export function getFunctionName(node: Node | BabelNode) {
   if ("id" in node && node.id) {
     return getFunctionName(node.id);
   }
+
+  if ("key" in node && node.key) {
+    return getFunctionName(node.key);
+  }
 }
 
 function setSkipped(node: Node | BabelNode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,10 @@ export default async function convert<T = Node, Program = T & { type: "Program" 
           body: [],
         },
         params: [],
+        id:
+          babelNode.key.type === "Identifier"
+            ? { type: "Identifier", name: babelNode.key.name, start: 0, end: 0 }
+            : null,
       };
 
       mapper.onFunction(node, {
@@ -110,6 +114,10 @@ export default async function convert<T = Node, Program = T & { type: "Program" 
           body: [],
         },
         params: [],
+        id:
+          babelNode.key.type === "Identifier"
+            ? { type: "Identifier", name: babelNode.key.name, start: 0, end: 0 }
+            : null,
       };
 
       mapper.onFunction(node, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,12 @@ export default async function convert<T = Node, Program = T & { type: "Program" 
         params: [],
         id:
           babelNode.key.type === "Identifier"
-            ? { type: "Identifier", name: babelNode.key.name, start: 0, end: 0 }
+            ? {
+                type: "Identifier",
+                name: babelNode.key.name,
+                start: babelNode.key.start!,
+                end: babelNode.key.end!,
+              }
             : null,
       };
 
@@ -116,7 +121,12 @@ export default async function convert<T = Node, Program = T & { type: "Program" 
         params: [],
         id:
           babelNode.key.type === "Identifier"
-            ? { type: "Identifier", name: babelNode.key.name, start: 0, end: 0 }
+            ? {
+                type: "Identifier",
+                name: babelNode.key.name,
+                start: babelNode.key.start!,
+                end: babelNode.key.end!,
+              }
             : null,
       };
 

--- a/test/fixtures/class-method/sources.ts
+++ b/test/fixtures/class-method/sources.ts
@@ -1,0 +1,22 @@
+class Greeter {
+  greet() {
+    return "Covered class method";
+  }
+
+  uncovered() {
+    return "Uncovered class method";
+  }
+}
+
+const utils = {
+  double(value: number) {
+    return value * 2;
+  },
+
+  unused(value: number) {
+    return value / 2;
+  },
+};
+
+new Greeter().greet();
+utils.double(2);

--- a/test/function-coverage.test.ts
+++ b/test/function-coverage.test.ts
@@ -40,3 +40,31 @@ test("function expression", async ({ actual, expected }) => {
 
   assertCoverage(actual, expected);
 });
+
+test("class method", async ({ actual, expected }) => {
+  expect(actual).toMatchInlineSnapshot(`
+    {
+      "branches": "0/0 (100%)",
+      "functions": "2/4 (50%)",
+      "lines": "5/7 (71.42%)",
+      "statements": "5/7 (71.42%)",
+    }
+  `);
+
+  assertCoverage(actual, expected);
+
+  // Class and object method names should resolve instead of falling back to
+  // "(anonymous_N)". See https://github.com/AriPerkkio/ast-v8-to-istanbul/issues/162
+  const names = Object.values(actual.fnMap)
+    .map((fn) => fn.name)
+    .sort();
+
+  expect(names).toMatchInlineSnapshot(`
+    [
+      "double",
+      "greet",
+      "uncovered",
+      "unused",
+    ]
+  `);
+});


### PR DESCRIPTION
Method definitions carry their name on the `key` node, but getFunctionName only looked at `id`. Fall back to `key` so class/object methods resolve to their real names instead of "(anonymous_N)".

Fixes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function-name resolution so class and object methods show correct names (not anonymous) in coverage reports.
* **Tests**
  * Added tests and fixtures to validate coverage and method-name resolution for class and object methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->