### PR TITLE
fix: generate only unique names in `fnMap`

### DIFF
--- a/src/coverage-map.ts
+++ b/src/coverage-map.ts
@@ -20,6 +20,7 @@ type Meta = {
   lastBranch: number;
   lastStatement: number;
   seen: Record<string, number>;
+  fnNames: Map<string, number>;
 };
 
 export function createCoverageMapData(filename: string, sourceMap: TraceMap) {
@@ -42,6 +43,7 @@ export function createCoverageMapData(filename: string, sourceMap: TraceMap) {
       lastFunction: 0,
       lastStatement: 0,
       seen: {},
+      fnNames: new Map(),
     };
 
     data[path] = {
@@ -80,8 +82,19 @@ export function addFunction(options: {
     meta.lastFunction++;
     meta.seen[key] = index;
 
+    let name = options.name;
+
+    if (name) {
+      const count = (meta.fnNames.get(name) || 0) + 1;
+      meta.fnNames.set(name, count);
+
+      if (count > 1) {
+        name += `_${count}`;
+      }
+    }
+
     fileCoverage.fnMap[index] = {
-      name: options.name || `(anonymous_${index})`,
+      name: name || `(anonymous_${index})`,
       decl: pickLocation(options.decl),
       loc: pickLocation(options.loc),
       line: options.loc.start.line,

--- a/src/coverage-map.ts
+++ b/src/coverage-map.ts
@@ -85,11 +85,19 @@ export function addFunction(options: {
     let name = options.name;
 
     if (name) {
-      const count = (meta.fnNames.get(name) || 0) + 1;
-      meta.fnNames.set(name, count);
+      const base = name;
+      let count = (meta.fnNames.get(base) || 0) + 1;
+      name = count > 1 ? `${base}_${count}` : base;
 
-      if (count > 1) {
-        name += `_${count}`;
+      while (meta.fnNames.has(name)) {
+        count++;
+        name = `${base}_${count}`;
+      }
+
+      meta.fnNames.set(base, count);
+
+      if (name !== base) {
+        meta.fnNames.set(name, 0);
       }
     }
 

--- a/test/fixtures/class-method/sources.ts
+++ b/test/fixtures/class-method/sources.ts
@@ -1,4 +1,6 @@
 class Greeter {
+  constructor() {}
+
   greet() {
     return "Covered class method";
   }
@@ -6,6 +8,13 @@ class Greeter {
   uncovered() {
     return "Uncovered class method";
   }
+}
+
+// To make name generation complex
+const anonymous = function () {}
+
+class Another {
+  constructor() {}
 }
 
 const utils = {

--- a/test/fixtures/class-method/sources.ts
+++ b/test/fixtures/class-method/sources.ts
@@ -15,6 +15,14 @@ const anonymous = function () {}
 
 class Another {
   constructor() {}
+  constructor_2() {}
+  constructor_3() {}
+  constructor_4() {}
+  constructor_5() {}
+}
+
+class AndAnother {
+  constructor() {}
 }
 
 const utils = {

--- a/test/fixtures/function-declaration/sources.ts
+++ b/test/fixtures/function-declaration/sources.ts
@@ -18,7 +18,18 @@ export default function(a: number, b: number) {
   return sum(a, b) / 2;
 }
 
-subtract(2, 3);
+if (typeof sum === "function") {
+  function another() {
+    return 2;
+  }
 
-// TODO:
-// function noop() {}
+  another();
+} else {
+  function another() {
+    return 3;
+  }
+
+  another();
+}
+
+subtract(2, 3);

--- a/test/function-coverage.test.ts
+++ b/test/function-coverage.test.ts
@@ -90,7 +90,7 @@ test("class method", async ({ actual, expected }) => {
   expect(actual).toMatchInlineSnapshot(`
     {
       "branches": "0/0 (100%)",
-      "functions": "3/7 (42.85%)",
+      "functions": "3/12 (25%)",
       "lines": "6/8 (75%)",
       "statements": "6/8 (75%)",
     }
@@ -103,6 +103,11 @@ test("class method", async ({ actual, expected }) => {
       "(anonymous_3)",
       "constructor",
       "constructor_2",
+      "constructor_2_2",
+      "constructor_3",
+      "constructor_4",
+      "constructor_5",
+      "constructor_6",
       "double",
       "greet",
       "uncovered",

--- a/test/function-coverage.test.ts
+++ b/test/function-coverage.test.ts
@@ -1,16 +1,37 @@
 import { expect } from "vitest";
+import { type FileCoverage } from "istanbul-lib-coverage";
 
 import { assertCoverage, test } from "./utils";
 
 test("function declaration", async ({ actual, expected }) => {
   expect(actual).toMatchInlineSnapshot(`
     {
-      "branches": "0/0 (100%)",
-      "functions": "1/5 (20%)",
-      "lines": "2/6 (33.33%)",
-      "statements": "2/6 (33.33%)",
+      "branches": "1/2 (50%)",
+      "functions": "2/7 (28.57%)",
+      "lines": "5/11 (45.45%)",
+      "statements": "5/11 (45.45%)",
     }
   `);
+  expect(getNames(actual)).toMatchInlineSnapshot(`
+    [
+      "(anonymous_4)",
+      "another",
+      "another_2",
+      "multiply",
+      "remainder",
+      "subtract",
+      "sum",
+    ]
+  `);
+
+  // Remap name back to duplicate to match istanbuljs before comparing matching results
+  for (const index in actual.fnMap) {
+    const fn = actual.fnMap[index];
+
+    if (fn.name.startsWith("another")) {
+      fn.name = "another";
+    }
+  }
 
   assertCoverage(actual, expected);
 });
@@ -23,6 +44,20 @@ test("arrow function expression", async ({ actual, expected }) => {
       "lines": "11/15 (73.33%)",
       "statements": "12/16 (75%)",
     }
+  `);
+
+  expect(getNames(actual)).toMatchInlineSnapshot(`
+    [
+      "(anonymous_0)",
+      "(anonymous_1)",
+      "(anonymous_2)",
+      "(anonymous_3)",
+      "(anonymous_4)",
+      "(anonymous_5)",
+      "(anonymous_6)",
+      "(anonymous_7)",
+      "(anonymous_8)",
+    ]
   `);
 
   assertCoverage(actual, expected);
@@ -38,6 +73,16 @@ test("function expression", async ({ actual, expected }) => {
     }
   `);
 
+  expect(getNames(actual)).toMatchInlineSnapshot(`
+    [
+      "(anonymous_4)",
+      "multiply",
+      "remainder",
+      "subtract",
+      "sum",
+    ]
+  `);
+
   assertCoverage(actual, expected);
 });
 
@@ -45,26 +90,31 @@ test("class method", async ({ actual, expected }) => {
   expect(actual).toMatchInlineSnapshot(`
     {
       "branches": "0/0 (100%)",
-      "functions": "2/4 (50%)",
-      "lines": "5/7 (71.42%)",
-      "statements": "5/7 (71.42%)",
+      "functions": "3/7 (42.85%)",
+      "lines": "6/8 (75%)",
+      "statements": "6/8 (75%)",
     }
   `);
 
-  assertCoverage(actual, expected);
-
   // Class and object method names should resolve instead of falling back to
   // "(anonymous_N)". See https://github.com/AriPerkkio/ast-v8-to-istanbul/issues/162
-  const names = Object.values(actual.fnMap)
-    .map((fn) => fn.name)
-    .sort();
-
-  expect(names).toMatchInlineSnapshot(`
+  expect(getNames(actual)).toMatchInlineSnapshot(`
     [
+      "(anonymous_3)",
+      "constructor",
+      "constructor_2",
       "double",
       "greet",
       "uncovered",
       "unused",
     ]
   `);
+
+  assertCoverage(actual, expected);
 });
+
+function getNames(fileCoverage: FileCoverage) {
+  return Object.values(fileCoverage.fnMap)
+    .map((fn) => fn.name)
+    .sort();
+}


### PR DESCRIPTION
- Fixes https://github.com/AriPerkkio/ast-v8-to-istanbul/issues/169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage data to disambiguate duplicate function names by appending numeric suffixes and initializing per-file function-name metadata.

* **Tests**
  * Expanded and updated tests to assert function-name extraction and coverage behavior across complex function and class scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->