### PR TITLE
perf: sync AST `walk`, replace linear offset-to-needle scan with binary search

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -36,7 +36,7 @@ import type {
   BlockStatement,
   SwitchCase,
 } from "estree";
-import { asyncWalk } from "estree-walker";
+import { walk as walkAst } from "estree-walker";
 import { type IgnoreHint } from "./ignore-hints";
 
 declare module "estree" {
@@ -109,14 +109,14 @@ export function getWalker() {
     nextIgnore = node;
   }
 
-  async function walk(
+  function walk(
     ast: unknown,
     ignoreHints: IgnoreHint[],
     ignoreClassMethods: string[] | undefined,
     visitors: Visitors,
   ) {
-    return await asyncWalk(ast as Node, {
-      async enter(node) {
+    return walkAst(ast as Node, {
+      enter(node) {
         if (nextIgnore !== false) {
           return;
         }
@@ -333,7 +333,7 @@ export function getWalker() {
           }
         }
       },
-      async leave(node) {
+      leave(node) {
         if (node === nextIgnore) {
           nextIgnore = false;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default async function convert<T = Node, Program = T & { type: "Program" 
   const mapper = await CoverageMapper.create<T, Program>(options, walker.onIgnore);
   const ast = await options.ast;
 
-  await walker.walk(ast, ignoreHints, options.ignoreClassMethods, {
+  walker.walk(ast, ignoreHints, options.ignoreClassMethods, {
     // Functions
     onFunctionDeclaration(node) {
       mapper.onFunction(node, {

--- a/src/location.ts
+++ b/src/location.ts
@@ -19,60 +19,47 @@ const WORD_PATTERN = /(\w+|\s|[^\w\s])/g;
 const INLINE_MAP_PATTERN = /#\s*sourceMappingURL=(.*)\s*$/m;
 const BASE_64_PREFIX = "data:application/json;base64,";
 
-/** How often should offset calculations be cached */
-const CACHE_THRESHOLD = 250;
+const NEW_LINE_CHAR_CODE = "\n".charCodeAt(0);
 
 type Filename = string;
 
 export class Locator {
-  #cache = new Map<number, Needle>();
-  #codeParts: string[];
+  /** Offsets of each line's first character */
+  #lineStarts: number[] = [0];
   #map: TraceMap;
   #directory: string;
   #ignoredLines = new Map<Filename, ReturnType<typeof getIgnoredLines>>();
 
   constructor(code: string, map: TraceMap, directory: string) {
-    this.#codeParts = code.split("");
+    for (let offset = 0; offset < code.length; offset++) {
+      if (code.charCodeAt(offset) === NEW_LINE_CHAR_CODE) {
+        this.#lineStarts.push(offset + 1);
+      }
+    }
     this.#map = map;
     this.#directory = directory;
   }
 
   reset() {
-    this.#cache.clear();
     this.#ignoredLines.clear();
-    this.#codeParts = [];
+    this.#lineStarts = [0];
   }
 
   offsetToNeedle(offset: number): Needle {
-    const closestThreshold = Math.floor(offset / CACHE_THRESHOLD) * CACHE_THRESHOLD;
-    const cacheHit = this.#cache.get(closestThreshold);
+    let low = 0;
+    let high = this.#lineStarts.length - 1;
 
-    let current = cacheHit ? closestThreshold : 0;
-    let line = cacheHit?.line ?? 1;
-    let column = cacheHit?.column ?? 0;
+    while (low <= high) {
+      const mid = (low + high) >> 1;
 
-    for (let i = current; i <= this.#codeParts.length; i++) {
-      if (current === offset) {
-        return { line, column };
-      }
-
-      if (current % CACHE_THRESHOLD === 0) {
-        this.#cache.set(current, { line, column });
-      }
-
-      const char = this.#codeParts[i];
-
-      if (char === "\n") {
-        line++;
-        column = 0;
+      if (this.#lineStarts[mid] <= offset) {
+        low = mid + 1;
       } else {
-        column++;
+        high = mid - 1;
       }
-
-      current++;
     }
 
-    return { line, column };
+    return { line: high + 1, column: offset - this.#lineStarts[high] };
   }
 
   getLoc(node: Pick<Node, "start" | "end">) {


### PR DESCRIPTION
- Upstreaming improvements from https://github.com/web-infra-dev/rstest/pull/1490.
- Some easy perf wins. Fable does it better than me. 🙃 

> # Benchmark log (pnpm run test --run --project e2e --reporter=verbose)
> 
> ## Baseline (main, 3e599fc + fresh install/build)
> 
> | Test                      | Run 1 | Run 2 | Run 3 | Median |
> | ------------------------- | ----- | ----- | ----- | ------ |
> | checker.ts                | 4861  | 4805  | 4822  | 4822   |
> | functions.ts              | 4659  | 4466  | 4639  | 4639   |
> | vitest-cli-api-bundled.js | 3184  | 3086  | 3163  | 3163   |
> | tests total (s)           | 12.70 | 12.36 | 12.62 | 12.62  |
> 
> ## Step 2: sync walk (perf/sync-walk, ast.ts asyncWalk → walk)
> 
> | Test                      | Run 1 | Run 2 | Run 3 | Median | vs baseline |
> | ------------------------- | ----- | ----- | ----- | ------ | ----------- |
> | checker.ts                | 4754  | 4784  | 4744  | 4754   | -1.4%       |
> | functions.ts              | 4571  | 4583  | 4511  | 4571   | -1.5%       |
> | vitest-cli-api-bundled.js | 3104  | 3142  | 3116  | 3116   | -1.5%       |
> | tests total (s)           | 12.43 | 12.51 | 12.37 | 12.43  | -1.5%       |
> 
> ## Step 3: sync walk + line-starts locator (location.ts binary search)
> 
> | Test                      | Run 1 | Run 2 | Run 3 | Median | vs baseline |
> | ------------------------- | ----- | ----- | ----- | ------ | ----------- |
> | checker.ts                | 3317  | 3244  | 3218  | 3244   | -33% (1.5x) |
> | functions.ts              | 472   | 484   | 473   | 473    | -90% (9.8x) |
> | vitest-cli-api-bundled.js | 627   | 637   | 618   | 627    | -80% (5.0x) |
> | tests total (s)           | 5.48  | 5.42  | 5.38  | 5.42   | -57% (2.3x) |
> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved source location lookups, especially for larger files.
  * Streamlined code traversal and conversion processing for more immediate results.

* **Bug Fixes**
  * Improved consistency when calculating line and column positions across source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->