### PR TITLE
perf: skip tokenization if no ignore hints are found

### DIFF
--- a/src/ignore-hints.ts
+++ b/src/ignore-hints.ts
@@ -8,6 +8,9 @@ export interface IgnoreHint {
 const IGNORE_PATTERN =
   /^\s*(?:istanbul|[cv]8|node:coverage)\s+ignore\s+(if|else|next|file)(?=\W|$)/;
 
+const IGNORE_CANDIDATE_PATTERN =
+  /(?:istanbul|[cv]8|node:coverage)\s+ignore\s+(if|else|next|file)(?=\W|$)/;
+
 const IGNORE_LINES_PATTERN = /\s*(?:istanbul|[cv]8|node:coverage)\s+ignore\s+(start|stop)(?=\W|$)/;
 
 const EOL_PATTERN = /\r?\n/g;
@@ -17,6 +20,11 @@ const EOL_PATTERN = /\r?\n/g;
  * - Most AST parsers don't emit comments in AST like Acorn does, so parse comments manually instead.
  */
 export function getIgnoreHints(code: string): IgnoreHint[] {
+  // Only tokenize candidates to distinguish real comments from strings and other code.
+  if (!IGNORE_CANDIDATE_PATTERN.test(code)) {
+    return [];
+  }
+
   const ignoreHints: IgnoreHint[] = [];
   const tokens = jsTokens(code);
 

--- a/test/ignore-hints.test.ts
+++ b/test/ignore-hints.test.ts
@@ -1,7 +1,10 @@
 import { EOL } from "node:os";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import jsTokens from "js-tokens";
 
 import { getIgnoredLines, getIgnoreHints } from "../src/ignore-hints";
+
+vi.mock("js-tokens", { spy: true });
 
 const tools = ["istanbul", "v8", "c8", "node:coverage"];
 
@@ -109,5 +112,17 @@ export function hello5(): string {
     expect([...getIgnoredLines(code)]).toStrictEqual([
       5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21,
     ]);
+  });
+
+  test("bails out early if no ignore hints are found", () => {
+    const code = `\
+export function hello1(): string {
+  return "Hello1"
+}
+`.replaceAll("\n", EOL);
+
+    expect.soft([...getIgnoreHints(code)]).toStrictEqual([]);
+
+    expect.soft(vi.mocked(jsTokens)).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Results from CI, `main` vs this branch:

| Runner         | Node.js | Fixture                     | Main (ms) | PR (ms) | Time change |
| -------------- | ------: | --------------------------- | --------: | ------: | ----------: |
| ubuntu-latest  |      22 | `vitest-cli-api-bundled.js` |    276.42 |  194.20 |      -29.7% |
| ubuntu-latest  |      22 | `functions.ts`              |    317.12 |  179.78 |      -43.3% |
| ubuntu-latest  |      22 | `checker.ts`                |   1230.53 |  661.43 |      -46.2% |
| ubuntu-latest  |      24 | `vitest-cli-api-bundled.js` |    271.04 |  273.20 |       +0.8% |
| ubuntu-latest  |      24 | `functions.ts`              |    340.20 |  245.03 |      -28.0% |
| ubuntu-latest  |      24 | `checker.ts`                |   1347.06 |  971.19 |      -27.9% |
| macos-latest   |      22 | `vitest-cli-api-bundled.js` |    211.48 |  344.73 |      +63.0% |
| macos-latest   |      22 | `functions.ts`              |    312.98 |  283.22 |       -9.5% |
| macos-latest   |      22 | `checker.ts`                |   1253.05 |  871.98 |      -30.4% |
| macos-latest   |      24 | `vitest-cli-api-bundled.js` |    285.24 |  160.61 |      -43.7% |
| macos-latest   |      24 | `functions.ts`              |    413.78 |  152.02 |      -63.3% |
| macos-latest   |      24 | `checker.ts`                |   1438.66 |  592.33 |      -58.8% |
| windows-latest |      22 | `vitest-cli-api-bundled.js` |    337.47 |  336.65 |       -0.2% |
| windows-latest |      22 | `functions.ts`              |    383.46 |  312.20 |      -18.6% |
| windows-latest |      22 | `checker.ts`                |   1441.41 | 1077.44 |      -25.3% |
| windows-latest |      24 | `vitest-cli-api-bundled.js` |    270.97 |  278.93 |       +2.9% |
| windows-latest |      24 | `functions.ts`              |    310.87 |  249.17 |      -19.8% |
| windows-latest |      24 | `checker.ts`                |   1274.50 | 1037.80 |      -18.6% |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved processing for source code without ignore hints by quickly determining when no relevant text is present.
  - Avoids unnecessary code analysis in these cases, improving efficiency without changing results.

- **Tests**
  - Added coverage verifying that unnecessary tokenization is skipped when no ignore hints are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->